### PR TITLE
Fix motor drift by removing blocking delay

### DIFF
--- a/src/CastleBoard.cpp
+++ b/src/CastleBoard.cpp
@@ -62,7 +62,6 @@ void processCommand(byte cmd, byte len, byte* data) {
   if (cmd == 1) { // Get all pots
     Serial.println("Recebeu CMD1 lê os potenciometros");
     fetchAllPots();
-    delay(500);
     sendResponse(CASTLE_ID, 1, 22, pot_values);
   } else if (cmd == 2 && len == 2) { // Set target
     Serial.println("Recebeu CMD2 Irá mover motor");

--- a/src/CastleBoard.cpp
+++ b/src/CastleBoard.cpp
@@ -69,7 +69,6 @@ void processCommand(byte cmd, byte len, byte* data) {
     byte motor_index = data[0]; // 0-21
     byte value = data[1]; // 0-99
     setMotorTarget(motor_index, value);
-    delay(50 * value); // motor demora para mexer, então esperamos 500ms por cada valor 
     sendResponse(CASTLE_ID, 2, 0, NULL);
   }
   if (!Wire.available()){

--- a/src/PlacaDisplay0.1.0.cpp.off
+++ b/src/PlacaDisplay0.1.0.cpp.off
@@ -39,6 +39,8 @@ const int lockPressDuration = 2000; // 2 seconds to lock/unlock
 
 int valueCh1 = 0; // Current value for Channel 1 (0-99)
 int valueCh2 = 0; // Current value for Channel 2 (0-99)
+int targetCh1 = 0; // User-set target for Channel 1 (0-99)
+int targetCh2 = 0; // User-set target for Channel 2 (0-99)
 unsigned long lastButtonTimeCh1 = 0;
 unsigned long lastButtonTimeCh2 = 0;
 unsigned long lastChangeTimeCh1 = 0; // Time of last Ch1 value change
@@ -154,17 +156,19 @@ void handleButtons() {
       if (!lockedCh1) {
         if (upPressedCh1) {
           valueCh1 = min(99, valueCh1 + 1);
+          targetCh1 = valueCh1;
           lastButtonTimeCh1 = currentTime;
           lastChangeTimeCh1 = currentTime;
           blinkActiveCh1 = true;
           consolidatedCh1 = true;
         } else if (downPressedCh1) {
           valueCh1 = max(0, valueCh1 - 1);
+          targetCh1 = valueCh1;
           lastButtonTimeCh1 = currentTime;
           lastChangeTimeCh1 = currentTime;
           blinkActiveCh1 = true;
           consolidatedCh1 = true;
-        } 
+        }
         if ((upPressedCh1 == false && downPressedCh1 == false) && consolidatedCh1){
           sendI2C(1, valueCh1);
           delay(50);
@@ -207,12 +211,14 @@ void handleButtons() {
       if (!lockedCh2) {
         if (upPressedCh2) {
           valueCh2 = min(99, valueCh2 + 1);
+          targetCh2 = valueCh2;
           lastButtonTimeCh2 = currentTime;
           lastChangeTimeCh2 = currentTime;
           blinkActiveCh2 = true;
           sendI2C(2, valueCh2);
         } else if (downPressedCh2) {
           valueCh2 = max(0, valueCh2 - 1);
+          targetCh2 = valueCh2;
           lastButtonTimeCh2 = currentTime;
           lastChangeTimeCh2 = currentTime;
           blinkActiveCh2 = true;
@@ -304,19 +310,39 @@ void receiveEvent(int howMany) {
     Serial.print(", Value=");
     Serial.println(receivedValue);
 
-    if (type == 1) { // Only update actuals (potentiometer values)
+    if (type == 0) { // Target initialization - set both target and display
+      if (channel == 1 && !lockedCh1) {
+        targetCh1 = constrain(receivedValue, 0, 99);
+        valueCh1 = targetCh1;
+        lastChangeTimeCh1 = millis();
+        blinkActiveCh1 = true;
+        Serial.print("Initialized Ch1 target and value to ");
+        Serial.println(targetCh1);
+      } else if (channel == 2 && !lockedCh2) {
+        targetCh2 = constrain(receivedValue, 0, 99);
+        valueCh2 = targetCh2;
+        lastChangeTimeCh2 = millis();
+        blinkActiveCh2 = true;
+        Serial.print("Initialized Ch2 target and value to ");
+        Serial.println(targetCh2);
+      }
+    } else if (type == 1) { // Actual - only update display, preserve target
       if (channel == 1 && !lockedCh1) {
         valueCh1 = constrain(receivedValue, 0, 99);
         lastChangeTimeCh1 = millis();
         blinkActiveCh1 = true;
-        Serial.print("Updated Ch1 to ");
-        Serial.println(valueCh1);
+        Serial.print("Updated Ch1 display to ");
+        Serial.print(valueCh1);
+        Serial.print(", target remains ");
+        Serial.println(targetCh1);
       } else if (channel == 2 && !lockedCh2) {
         valueCh2 = constrain(receivedValue, 0, 99);
         lastChangeTimeCh2 = millis();
         blinkActiveCh2 = true;
-        Serial.print("Updated Ch2 to ");
-        Serial.println(valueCh2);
+        Serial.print("Updated Ch2 display to ");
+        Serial.print(valueCh2);
+        Serial.print(", target remains ");
+        Serial.println(targetCh2);
       }
     }
   }
@@ -329,17 +355,17 @@ void receiveEvent(int howMany) {
 
 // I2C request event
 void requestEvent() {
-  // Respond with both channels' values
+  // Respond with both channels' TARGET values (not display values)
   Wire.write((byte)1); // Channel 1 identifier
-  Wire.write((byte)(valueCh1 & 0xFF)); // Channel 1 value
+  Wire.write((byte)(targetCh1 & 0xFF)); // Channel 1 target
   Wire.write((byte)2); // Channel 2 identifier
-  Wire.write((byte)(valueCh2 & 0xFF)); // Channel 2 value
+  Wire.write((byte)(targetCh2 & 0xFF)); // Channel 2 target
   
   // Log request response payload
-  Serial.print("I2C Request Out: Channel=1, Value=");
-  Serial.print(valueCh1);
-  Serial.print("; Channel=2, Value=");
-  Serial.println(valueCh2);
+  Serial.print("I2C Request Out: Channel=1, Target=");
+  Serial.print(targetCh1);
+  Serial.print("; Channel=2, Target=");
+  Serial.println(targetCh2);
 }
 
 // Update 7-segment display with multiplexing


### PR DESCRIPTION
# Fix motor control drift and startup issues

## Summary
This PR resolves two critical motor control issues reported during hardware testing:

1. **Motors stopping at intermediate values**: When setting a motor to move from 0→27, it would stop at ~10-11 instead of reaching the target
2. **Motors resetting to zero at startup**: Motors would move to zero position on power-up instead of maintaining their last position

The root cause was a **destructive feedback loop** in the display board logic combined with **blocking communication delays**.

### Key Changes
- **CastleBoard.cpp**: Removed blocking delays (500ms pot read delay + 50ms×value motor delay) to enable non-blocking communication
- **PlacaDisplay0.1.0.cpp.off**: Separated user-set targets from displayed feedback values to break the feedback loop:
  - Added `targetCh1`/`targetCh2` variables to preserve user intent
  - Modified `receiveEvent()` to handle target initialization (type=0) vs actual updates (type=1) 
  - Changed `requestEvent()` to return target values (not display values) to MainBoard
  - Updated button handlers to maintain both target and display values

### Root Cause Analysis
The feedback loop occurred because:
1. User sets target 27 → `valueCh1 = 27`
2. Motor starts moving, potentiometer reads 11 (intermediate position)
3. MainBoard sends actual=11 to display with `type=1`
4. Display **overwrote** user target: `valueCh1 = 11` (target lost!)
5. MainBoard polls display, gets 11 back as "target"
6. Motor stops at 11 instead of reaching 27

## Review & Testing Checklist for Human
This PR contains **HIGH RISK** changes that require thorough hardware testing:

- [ ] **Test motor positioning accuracy**: Set display to 27, verify motor reaches exactly 27 (not ~10-11)
- [ ] **Test startup behavior**: Power cycle system, verify motors maintain last position (don't reset to zero)
- [ ] **Test target preservation**: While motor is moving, verify display shows real-time position but MainBoard still gets original target when polled
- [ ] **Test locked channel behavior**: Verify target/display separation works correctly when channels are locked/unlocked
- [ ] **Test communication reliability**: Verify I2C/Serial communication works reliably without the removed delays

### Test Plan
1. Set motor targets to various values (0, 27, 50, 99) and verify motors reach exact targets
2. Power cycle the system multiple times and verify motors don't move from their last positions
3. Monitor serial debug output to verify target vs display value separation is working correctly
4. Test rapid button presses and motor movements to verify no communication timeouts

### Notes
- This fix required understanding the complete data flow: Display → MainBoard → CastleBoard → MotorBoard → Potentiometer → back
- The architectural change separating targets from display values is complex but necessary to break the feedback loop
- **Critical limitation**: Unable to test on physical hardware - all verification must be done by reviewer with actual Arduino setup

**Link to Devin run**: https://app.devin.ai/sessions/3db3fce0793d4f29a9dc3850b08ae7ea  
**Requested by**: @mde-figu (Markus)