### PR TITLE
Fix button increment bug and startup zeros

### DIFF
--- a/src/MainBoard0.1.0.cpp.off
+++ b/src/MainBoard0.1.0.cpp.off
@@ -46,7 +46,9 @@ void setup() {
 
 void loop() {
   handleCastleSwitch();
-  pollTargets();
+  if (initial_setup_done) {
+    pollTargets();
+  }
   if (millis() - last_poll >= POLL_INTERVAL) {
     last_poll = millis();
     pollActualsAndUpdate();

--- a/src/PlacaDisplay0.1.0.cpp.off
+++ b/src/PlacaDisplay0.1.0.cpp.off
@@ -155,15 +155,15 @@ void handleButtons() {
       lockPressActiveCh1 = false; // Reset if both buttons aren't pressed
       if (!lockedCh1) {
         if (upPressedCh1) {
-          valueCh1 = min(99, valueCh1 + 1);
-          targetCh1 = valueCh1;
+          targetCh1 = min(99, targetCh1 + 1);
+          valueCh1 = targetCh1;
           lastButtonTimeCh1 = currentTime;
           lastChangeTimeCh1 = currentTime;
           blinkActiveCh1 = true;
           consolidatedCh1 = true;
         } else if (downPressedCh1) {
-          valueCh1 = max(0, valueCh1 - 1);
-          targetCh1 = valueCh1;
+          targetCh1 = max(0, targetCh1 - 1);
+          valueCh1 = targetCh1;
           lastButtonTimeCh1 = currentTime;
           lastChangeTimeCh1 = currentTime;
           blinkActiveCh1 = true;
@@ -210,15 +210,15 @@ void handleButtons() {
       lockPressActiveCh2 = false; // Reset if both buttons aren't pressed
       if (!lockedCh2) {
         if (upPressedCh2) {
-          valueCh2 = min(99, valueCh2 + 1);
-          targetCh2 = valueCh2;
+          targetCh2 = min(99, targetCh2 + 1);
+          valueCh2 = targetCh2;
           lastButtonTimeCh2 = currentTime;
           lastChangeTimeCh2 = currentTime;
           blinkActiveCh2 = true;
           sendI2C(2, valueCh2);
         } else if (downPressedCh2) {
-          valueCh2 = max(0, valueCh2 - 1);
-          targetCh2 = valueCh2;
+          targetCh2 = max(0, targetCh2 - 1);
+          valueCh2 = targetCh2;
           lastButtonTimeCh2 = currentTime;
           lastChangeTimeCh2 = currentTime;
           blinkActiveCh2 = true;


### PR DESCRIPTION
# Fix button increment bug and startup zeros

## Summary
Fixes two critical motor control issues identified through code analysis and simulation:

1. **Button drift bug**: Display button handlers were incrementing `valueCh1/valueCh2` (rounded-down feedback values) instead of `targetCh1/targetCh2` (user's intended targets). This caused motors to get stuck at intermediate values due to cumulative rounding errors from integer division in `map()` functions.

2. **Startup zeros bug**: `pollTargets()` was running immediately in `loop()` before `initial_setup_done` flag was set, causing MainBoard to read uninitialized zeros from displays and send them to motors during startup.

**Root cause analysis:**
- Python simulation showed 1 unit loss per feedback cycle (set 15→reads 14, set 18→reads 17)  
- Button handlers incremented the lossy feedback value instead of preserving user intent
- Startup sequence allowed polling before `switchCastle()` completed initialization

## Review & Testing Checklist for Human

- [ ] **Hardware startup test**: Power cycle system multiple times, verify motors stay at last position (don't reset to zero)
- [ ] **Target accuracy test**: Set display to 15, verify motor reaches exactly 15 (not 9 or other intermediate value) 
- [ ] **Progressive increment test**: Press up button 5 times from 0, verify display/motor go 0→1→2→3→4→5 without getting stuck
- [ ] **Button regression test**: Verify all button features still work (locking via simultaneous press, debouncing, blinking, consolidation)
- [ ] **End-to-end system test**: Test complete workflow across all 4 CastleBoards with castle switching

### Notes
**Risk level: MEDIUM** - Changes are minimal and logical, but this is critical motor control code that cannot be tested without physical hardware. The button increment fix addresses the exact symptom reported (15→9, 18→17), and the startup guard prevents known initialization race condition.

**Link to Devin run**: https://app.devin.ai/sessions/3db3fce0793d4f29a9dc3850b08ae7ea  
**Requested by**: @mde-figu