### PR TITLE
Fix Ch2 consolidation and motor control issues

### DIFF
--- a/src/MainBoard0.1.0.cpp.off
+++ b/src/MainBoard0.1.0.cpp.off
@@ -18,7 +18,7 @@ unsigned long last_poll = 0;
 unsigned long last_button_time = 0;
 bool initial_setup_done = false;
 void handleCastleSwitch();
-void switchCastle(byte castle);
+bool switchCastle(byte castle);
 void pollTargets();
 void pollActualsAndUpdate();
 void sendToDisplays(byte type, byte* values);
@@ -39,7 +39,22 @@ void setup() {
 
   // Wait for boards to initialize
   delay(2000);
-  switchCastle(current_castle); // Initial setup
+  
+  byte retry_count = 0;
+  const byte MAX_RETRIES = 5;
+  while (!switchCastle(current_castle) && retry_count < MAX_RETRIES) {
+    retry_count++;
+    Serial.print("Retrying switchCastle, attempt ");
+    Serial.print(retry_count);
+    Serial.print("/");
+    Serial.println(MAX_RETRIES);
+    delay(1000);
+  }
+  
+  if (retry_count >= MAX_RETRIES) {
+    Serial.println("WARNING: Failed to initialize castle after max retries");
+  }
+  
   initial_setup_done = true;
   Serial.println("MainBoard started");
 }
@@ -60,21 +75,27 @@ void handleCastleSwitch() {
   if (current_time - last_button_time > DEBOUNCE_TIME) {
     if (digitalRead(CASTLE_UP_PIN) == LOW) {
       current_castle = min(4, current_castle + 1);
-      switchCastle(current_castle);
+      if (switchCastle(current_castle)) {
+        Serial.print("Switched to Castle ");
+        Serial.println(current_castle);
+      } else {
+        Serial.println("Failed to switch castle");
+      }
       last_button_time = current_time;
-      Serial.print("Switched to Castle ");
-      Serial.println(current_castle);
     } else if (digitalRead(CASTLE_DOWN_PIN) == LOW) {
       current_castle = max(1, current_castle - 1);
-      switchCastle(current_castle);
+      if (switchCastle(current_castle)) {
+        Serial.print("Switched to Castle ");
+        Serial.println(current_castle);
+      } else {
+        Serial.println("Failed to switch castle");
+      }
       last_button_time = current_time;
-      Serial.print("Switched to Castle ");
-      Serial.println(current_castle);
     }
   }
 }
 
-void switchCastle(byte castle) {
+bool switchCastle(byte castle) {
   byte pots[22];
   if (getPotsFromCastle(castle, pots)) {
     memcpy(targets, pots, sizeof(pots));
@@ -82,8 +103,10 @@ void switchCastle(byte castle) {
     sendToDisplays(0, pots); // Targets
     sendToDisplays(1, pots); // Actuals
     Serial.println("Castle switch: Pots updated and sent to displays");
+    return true;
   } else {
     Serial.println("Castle switch: Failed to get pots");
+    return false;
   }
 }
 

--- a/src/PlacaDisplay0.1.0.cpp.off
+++ b/src/PlacaDisplay0.1.0.cpp.off
@@ -59,6 +59,9 @@ bool lockPressActiveCh1 = false; // Whether Ch1 lock press is being detected
 bool lockPressActiveCh2 = false; // Whether Ch2 lock press is being detected
 bool consolidatedCh1 = false;
 bool consolidatedCh2 = false;
+unsigned long lastUserInteractionCh1 = 0;
+unsigned long lastUserInteractionCh2 = 0;
+const unsigned long SETTLING_PERIOD = 2000;
 
 // Function prototypes
 void receiveEvent(int howMany);
@@ -159,6 +162,7 @@ void handleButtons() {
           valueCh1 = targetCh1;
           lastButtonTimeCh1 = currentTime;
           lastChangeTimeCh1 = currentTime;
+          lastUserInteractionCh1 = currentTime;
           blinkActiveCh1 = true;
           consolidatedCh1 = true;
         } else if (downPressedCh1) {
@@ -166,6 +170,7 @@ void handleButtons() {
           valueCh1 = targetCh1;
           lastButtonTimeCh1 = currentTime;
           lastChangeTimeCh1 = currentTime;
+          lastUserInteractionCh1 = currentTime;
           blinkActiveCh1 = true;
           consolidatedCh1 = true;
         }
@@ -214,28 +219,30 @@ void handleButtons() {
           valueCh2 = targetCh2;
           lastButtonTimeCh2 = currentTime;
           lastChangeTimeCh2 = currentTime;
+          lastUserInteractionCh2 = currentTime;
           blinkActiveCh2 = true;
-          sendI2C(2, valueCh2);
+          consolidatedCh2 = true;
         } else if (downPressedCh2) {
           targetCh2 = max(0, targetCh2 - 1);
           valueCh2 = targetCh2;
           lastButtonTimeCh2 = currentTime;
           lastChangeTimeCh2 = currentTime;
+          lastUserInteractionCh2 = currentTime;
           blinkActiveCh2 = true;
-          sendI2C(2, valueCh2);
+          consolidatedCh2 = true;
         }
         if ((upPressedCh2 == false && downPressedCh2 == false) && consolidatedCh2){
-          sendI2C(1, valueCh2);
+          sendI2C(2, valueCh2);
           delay(50);
-          sendI2C(1, valueCh2);
+          sendI2C(2, valueCh2);
           delay(50);
-          sendI2C(1, valueCh2);
+          sendI2C(2, valueCh2);
           delay(50);
-          sendI2C(1, valueCh2);
+          sendI2C(2, valueCh2);
           delay(50);
-          sendI2C(1, valueCh2);
+          sendI2C(2, valueCh2);
           consolidatedCh2 = false;
-          Serial.println("ENVIOU VALOR CONSOLIDADO");
+          Serial.println("ENVIOU VALOR CONSOLIDADO CH2");
         }
       }
     }
@@ -327,22 +334,31 @@ void receiveEvent(int howMany) {
         Serial.println(targetCh2);
       }
     } else if (type == 1) { // Actual - only update display, preserve target
+      unsigned long currentTime = millis();
       if (channel == 1 && !lockedCh1) {
-        valueCh1 = constrain(receivedValue, 0, 99);
-        lastChangeTimeCh1 = millis();
-        blinkActiveCh1 = true;
-        Serial.print("Updated Ch1 display to ");
-        Serial.print(valueCh1);
-        Serial.print(", target remains ");
-        Serial.println(targetCh1);
+        if (currentTime - lastUserInteractionCh1 > SETTLING_PERIOD) {
+          valueCh1 = constrain(receivedValue, 0, 99);
+          lastChangeTimeCh1 = currentTime;
+          blinkActiveCh1 = true;
+          Serial.print("Updated Ch1 display to ");
+          Serial.print(valueCh1);
+          Serial.print(", target remains ");
+          Serial.println(targetCh1);
+        } else {
+          Serial.println("Suppressed Ch1 type=1 update during settling period");
+        }
       } else if (channel == 2 && !lockedCh2) {
-        valueCh2 = constrain(receivedValue, 0, 99);
-        lastChangeTimeCh2 = millis();
-        blinkActiveCh2 = true;
-        Serial.print("Updated Ch2 display to ");
-        Serial.print(valueCh2);
-        Serial.print(", target remains ");
-        Serial.println(targetCh2);
+        if (currentTime - lastUserInteractionCh2 > SETTLING_PERIOD) {
+          valueCh2 = constrain(receivedValue, 0, 99);
+          lastChangeTimeCh2 = currentTime;
+          blinkActiveCh2 = true;
+          Serial.print("Updated Ch2 display to ");
+          Serial.print(valueCh2);
+          Serial.print(", target remains ");
+          Serial.println(targetCh2);
+        } else {
+          Serial.println("Suppressed Ch2 type=1 update during settling period");
+        }
       }
     }
   }

--- a/src/PlacaDisplay0.1.0.cpp.off
+++ b/src/PlacaDisplay0.1.0.cpp.off
@@ -59,9 +59,6 @@ bool lockPressActiveCh1 = false; // Whether Ch1 lock press is being detected
 bool lockPressActiveCh2 = false; // Whether Ch2 lock press is being detected
 bool consolidatedCh1 = false;
 bool consolidatedCh2 = false;
-unsigned long lastUserInteractionCh1 = 0;
-unsigned long lastUserInteractionCh2 = 0;
-const unsigned long SETTLING_PERIOD = 2000;
 
 // Function prototypes
 void receiveEvent(int howMany);
@@ -162,7 +159,6 @@ void handleButtons() {
           valueCh1 = targetCh1;
           lastButtonTimeCh1 = currentTime;
           lastChangeTimeCh1 = currentTime;
-          lastUserInteractionCh1 = currentTime;
           blinkActiveCh1 = true;
           consolidatedCh1 = true;
         } else if (downPressedCh1) {
@@ -170,7 +166,6 @@ void handleButtons() {
           valueCh1 = targetCh1;
           lastButtonTimeCh1 = currentTime;
           lastChangeTimeCh1 = currentTime;
-          lastUserInteractionCh1 = currentTime;
           blinkActiveCh1 = true;
           consolidatedCh1 = true;
         }
@@ -219,7 +214,6 @@ void handleButtons() {
           valueCh2 = targetCh2;
           lastButtonTimeCh2 = currentTime;
           lastChangeTimeCh2 = currentTime;
-          lastUserInteractionCh2 = currentTime;
           blinkActiveCh2 = true;
           consolidatedCh2 = true;
         } else if (downPressedCh2) {
@@ -227,7 +221,6 @@ void handleButtons() {
           valueCh2 = targetCh2;
           lastButtonTimeCh2 = currentTime;
           lastChangeTimeCh2 = currentTime;
-          lastUserInteractionCh2 = currentTime;
           blinkActiveCh2 = true;
           consolidatedCh2 = true;
         }
@@ -334,31 +327,22 @@ void receiveEvent(int howMany) {
         Serial.println(targetCh2);
       }
     } else if (type == 1) { // Actual - only update display, preserve target
-      unsigned long currentTime = millis();
       if (channel == 1 && !lockedCh1) {
-        if (currentTime - lastUserInteractionCh1 > SETTLING_PERIOD) {
-          valueCh1 = constrain(receivedValue, 0, 99);
-          lastChangeTimeCh1 = currentTime;
-          blinkActiveCh1 = true;
-          Serial.print("Updated Ch1 display to ");
-          Serial.print(valueCh1);
-          Serial.print(", target remains ");
-          Serial.println(targetCh1);
-        } else {
-          Serial.println("Suppressed Ch1 type=1 update during settling period");
-        }
+        valueCh1 = constrain(receivedValue, 0, 99);
+        lastChangeTimeCh1 = millis();
+        blinkActiveCh1 = true;
+        Serial.print("Updated Ch1 display to ");
+        Serial.print(valueCh1);
+        Serial.print(", target remains ");
+        Serial.println(targetCh1);
       } else if (channel == 2 && !lockedCh2) {
-        if (currentTime - lastUserInteractionCh2 > SETTLING_PERIOD) {
-          valueCh2 = constrain(receivedValue, 0, 99);
-          lastChangeTimeCh2 = currentTime;
-          blinkActiveCh2 = true;
-          Serial.print("Updated Ch2 display to ");
-          Serial.print(valueCh2);
-          Serial.print(", target remains ");
-          Serial.println(targetCh2);
-        } else {
-          Serial.println("Suppressed Ch2 type=1 update during settling period");
-        }
+        valueCh2 = constrain(receivedValue, 0, 99);
+        lastChangeTimeCh2 = millis();
+        blinkActiveCh2 = true;
+        Serial.print("Updated Ch2 display to ");
+        Serial.print(valueCh2);
+        Serial.print(", target remains ");
+        Serial.println(targetCh2);
       }
     }
   }


### PR DESCRIPTION
# Fix motor control drift and Ch2 button consolidation issues

## Summary
Addresses motor positioning problems reported by user where motors were resetting to zero at startup and Ch2 button presses weren't working consistently. 

**MainBoard changes:**
- Added retry logic (up to 5 attempts) for `switchCastle()` during startup initialization to prevent motors from defaulting to zero when potentiometer reading fails
- Changed `switchCastle()` to return success/failure status for better error handling

**PlacaDisplay changes:**  
- Fixed Ch2 button handling to use consolidation logic like Ch1 (set `consolidatedCh2 = true` on press, send 5x burst on release)
- Corrected Ch2 burst transmission channel number from 1 to 2
- Made Ch1 and Ch2 button logic completely identical

## Review & Testing Checklist for Human
- [ ] **Startup behavior**: Verify displays show correct potentiometer values (expected: 06 and 15) instead of resetting to zero
- [ ] **Ch2 button functionality**: Test that Ch2 up/down buttons work identically to Ch1 - single press should update display and move motor to exact target
- [ ] **Motor positioning accuracy**: Set various target values and verify motors reach exact positions without stopping at intermediate values or drifting
- [ ] **Ch1 regression test**: Ensure Ch1 button behavior remains unchanged and working correctly
- [ ] **Cross power-cycle test**: Verify motors maintain position across power cycles and don't reset to zero on startup

### Notes
⚠️ **Testing limitation**: These changes affect core motor control logic but cannot be fully validated without physical hardware testing. The consolidation logic and retry mechanisms need hardware verification.

**Link to Devin run:** https://app.devin.ai/sessions/3db3fce0793d4f29a9dc3850b08ae7ea  
**Requested by:** @mde-figu