### PR TITLE
Remove motorboard feedback - display values directly control motors

### DIFF
--- a/src/CastleBoard.cpp
+++ b/src/CastleBoard.cpp
@@ -59,9 +59,11 @@ void loop() {
 }
 
 void processCommand(byte cmd, byte len, byte* data) {
-  if (cmd == 1) { // Get all pots
-    Serial.println("Recebeu CMD1 lê os potenciometros");
-    fetchAllPots();
+  if (cmd == 1) { // Get all pots - NO FEEDBACK MODE
+    Serial.println("Recebeu CMD1 - No feedback mode, returning zeros");
+    for (byte i = 0; i < 22; i++) {
+      pot_values[i] = 0;
+    }
     sendResponse(CASTLE_ID, 1, 22, pot_values);
   } else if (cmd == 2 && len == 2) { // Set target
     Serial.println("Recebeu CMD2 Irá mover motor");
@@ -76,7 +78,9 @@ void processCommand(byte cmd, byte len, byte* data) {
     delay(500);
     Serial1.begin(9600);
     delay(500);
-    fetchAllPots();
+    for (byte i = 0; i < 22; i++) {
+      pot_values[i] = 0;
+    }
     sendResponse(CASTLE_ID, 1, 22, pot_values);
   }
 }

--- a/src/CastleBoard.cpp
+++ b/src/CastleBoard.cpp
@@ -62,7 +62,6 @@ void processCommand(byte cmd, byte len, byte* data) {
   if (cmd == 1) { // Get all pots
     Serial.println("Recebeu CMD1 lê os potenciometros");
     fetchAllPots();
-    delay(500);
     sendResponse(CASTLE_ID, 1, 22, pot_values);
   } else if (cmd == 2 && len == 2) { // Set target
     Serial.println("Recebeu CMD2 Irá mover motor");

--- a/src/CastleBoard.cpp
+++ b/src/CastleBoard.cpp
@@ -69,7 +69,6 @@ void processCommand(byte cmd, byte len, byte* data) {
     byte motor_index = data[0]; // 0-21
     byte value = data[1]; // 0-99
     setMotorTarget(motor_index, value);
-    delay(50 * value); // motor demora para mexer, então esperamos 500ms por cada valor 
     sendResponse(CASTLE_ID, 2, 0, NULL);
   }
   if (!Wire.available()){

--- a/src/PlacaDisplay0.1.0.cpp.off
+++ b/src/PlacaDisplay0.1.0.cpp.off
@@ -39,6 +39,8 @@ const int lockPressDuration = 2000; // 2 seconds to lock/unlock
 
 int valueCh1 = 0; // Current value for Channel 1 (0-99)
 int valueCh2 = 0; // Current value for Channel 2 (0-99)
+int targetCh1 = 0; // User-set target for Channel 1 (0-99)
+int targetCh2 = 0; // User-set target for Channel 2 (0-99)
 unsigned long lastButtonTimeCh1 = 0;
 unsigned long lastButtonTimeCh2 = 0;
 unsigned long lastChangeTimeCh1 = 0; // Time of last Ch1 value change
@@ -154,17 +156,19 @@ void handleButtons() {
       if (!lockedCh1) {
         if (upPressedCh1) {
           valueCh1 = min(99, valueCh1 + 1);
+          targetCh1 = valueCh1;
           lastButtonTimeCh1 = currentTime;
           lastChangeTimeCh1 = currentTime;
           blinkActiveCh1 = true;
           consolidatedCh1 = true;
         } else if (downPressedCh1) {
           valueCh1 = max(0, valueCh1 - 1);
+          targetCh1 = valueCh1;
           lastButtonTimeCh1 = currentTime;
           lastChangeTimeCh1 = currentTime;
           blinkActiveCh1 = true;
           consolidatedCh1 = true;
-        } 
+        }
         if ((upPressedCh1 == false && downPressedCh1 == false) && consolidatedCh1){
           sendI2C(1, valueCh1);
           delay(50);
@@ -207,12 +211,14 @@ void handleButtons() {
       if (!lockedCh2) {
         if (upPressedCh2) {
           valueCh2 = min(99, valueCh2 + 1);
+          targetCh2 = valueCh2;
           lastButtonTimeCh2 = currentTime;
           lastChangeTimeCh2 = currentTime;
           blinkActiveCh2 = true;
           sendI2C(2, valueCh2);
         } else if (downPressedCh2) {
           valueCh2 = max(0, valueCh2 - 1);
+          targetCh2 = valueCh2;
           lastButtonTimeCh2 = currentTime;
           lastChangeTimeCh2 = currentTime;
           blinkActiveCh2 = true;
@@ -304,19 +310,39 @@ void receiveEvent(int howMany) {
     Serial.print(", Value=");
     Serial.println(receivedValue);
 
-    if (type == 1) { // Only update actuals (potentiometer values)
+    if (type == 0) { // Target initialization - set both target and display
+      if (channel == 1 && !lockedCh1) {
+        targetCh1 = constrain(receivedValue, 0, 99);
+        valueCh1 = targetCh1;
+        lastChangeTimeCh1 = millis();
+        blinkActiveCh1 = true;
+        Serial.print("Initialized Ch1 target and value to ");
+        Serial.println(targetCh1);
+      } else if (channel == 2 && !lockedCh2) {
+        targetCh2 = constrain(receivedValue, 0, 99);
+        valueCh2 = targetCh2;
+        lastChangeTimeCh2 = millis();
+        blinkActiveCh2 = true;
+        Serial.print("Initialized Ch2 target and value to ");
+        Serial.println(targetCh2);
+      }
+    } else if (type == 1) { // Actual - only update display, preserve target
       if (channel == 1 && !lockedCh1) {
         valueCh1 = constrain(receivedValue, 0, 99);
         lastChangeTimeCh1 = millis();
         blinkActiveCh1 = true;
-        Serial.print("Updated Ch1 to ");
-        Serial.println(valueCh1);
+        Serial.print("Updated Ch1 display to ");
+        Serial.print(valueCh1);
+        Serial.print(", target remains ");
+        Serial.println(targetCh1);
       } else if (channel == 2 && !lockedCh2) {
         valueCh2 = constrain(receivedValue, 0, 99);
         lastChangeTimeCh2 = millis();
         blinkActiveCh2 = true;
-        Serial.print("Updated Ch2 to ");
-        Serial.println(valueCh2);
+        Serial.print("Updated Ch2 display to ");
+        Serial.print(valueCh2);
+        Serial.print(", target remains ");
+        Serial.println(targetCh2);
       }
     }
   }
@@ -329,17 +355,17 @@ void receiveEvent(int howMany) {
 
 // I2C request event
 void requestEvent() {
-  // Respond with both channels' values
+  // Respond with both channels' TARGET values (not display values)
   Wire.write((byte)1); // Channel 1 identifier
-  Wire.write((byte)(valueCh1 & 0xFF)); // Channel 1 value
+  Wire.write((byte)(targetCh1 & 0xFF)); // Channel 1 target
   Wire.write((byte)2); // Channel 2 identifier
-  Wire.write((byte)(valueCh2 & 0xFF)); // Channel 2 value
+  Wire.write((byte)(targetCh2 & 0xFF)); // Channel 2 target
   
   // Log request response payload
-  Serial.print("I2C Request Out: Channel=1, Value=");
-  Serial.print(valueCh1);
-  Serial.print("; Channel=2, Value=");
-  Serial.println(valueCh2);
+  Serial.print("I2C Request Out: Channel=1, Target=");
+  Serial.print(targetCh1);
+  Serial.print("; Channel=2, Target=");
+  Serial.println(targetCh2);
 }
 
 // Update 7-segment display with multiplexing

--- a/src/PlacaDisplay0.1.0.cpp.off
+++ b/src/PlacaDisplay0.1.0.cpp.off
@@ -37,10 +37,8 @@ const int lockPressDuration = 2000; // 2 seconds to lock/unlock
 #define CtrdigMSB_Ch2 12
 #define CtrdigLSB_Ch2 13
 
-int valueCh1 = 0; // Current value for Channel 1 (0-99)
-int valueCh2 = 0; // Current value for Channel 2 (0-99)
-int targetCh1 = 0; // User-set target for Channel 1 (0-99)
-int targetCh2 = 0; // User-set target for Channel 2 (0-99)
+int valueCh1 = 0; // Current value for Channel 1 (0-99) - NO FEEDBACK MODE
+int valueCh2 = 0; // Current value for Channel 2 (0-99) - NO FEEDBACK MODE
 unsigned long lastButtonTimeCh1 = 0;
 unsigned long lastButtonTimeCh2 = 0;
 unsigned long lastChangeTimeCh1 = 0; // Time of last Ch1 value change
@@ -156,14 +154,12 @@ void handleButtons() {
       if (!lockedCh1) {
         if (upPressedCh1) {
           valueCh1 = min(99, valueCh1 + 1);
-          targetCh1 = valueCh1;
           lastButtonTimeCh1 = currentTime;
           lastChangeTimeCh1 = currentTime;
           blinkActiveCh1 = true;
           consolidatedCh1 = true;
         } else if (downPressedCh1) {
           valueCh1 = max(0, valueCh1 - 1);
-          targetCh1 = valueCh1;
           lastButtonTimeCh1 = currentTime;
           lastChangeTimeCh1 = currentTime;
           blinkActiveCh1 = true;
@@ -211,14 +207,12 @@ void handleButtons() {
       if (!lockedCh2) {
         if (upPressedCh2) {
           valueCh2 = min(99, valueCh2 + 1);
-          targetCh2 = valueCh2;
           lastButtonTimeCh2 = currentTime;
           lastChangeTimeCh2 = currentTime;
           blinkActiveCh2 = true;
           sendI2C(2, valueCh2);
         } else if (downPressedCh2) {
           valueCh2 = max(0, valueCh2 - 1);
-          targetCh2 = valueCh2;
           lastButtonTimeCh2 = currentTime;
           lastChangeTimeCh2 = currentTime;
           blinkActiveCh2 = true;
@@ -291,15 +285,15 @@ void sendI2C(byte channel, int value) {
   Serial.println(value);
 }
 
-// I2C receive event
+// I2C receive event - NO FEEDBACK MODE
 void receiveEvent(int howMany) {
-  Serial.print("I2C Received: Address=0x");
+  Serial.print("I2C Received (NO FEEDBACK MODE): Address=0x");
   Serial.print(I2C_ADDRESS, HEX);
   Serial.print(", Bytes=");
   Serial.println(howMany);
 
   if (howMany >= 3) { // Expect [type, channel, value]
-    byte type = Wire.read(); // 0 for target, 1 for actual
+    byte type = Wire.read(); // 0 for target, 1 for actual (ignored in no-feedback mode)
     byte channel = Wire.read();
     int receivedValue = Wire.read();
 
@@ -310,41 +304,8 @@ void receiveEvent(int howMany) {
     Serial.print(", Value=");
     Serial.println(receivedValue);
 
-    if (type == 0) { // Target initialization - set both target and display
-      if (channel == 1 && !lockedCh1) {
-        targetCh1 = constrain(receivedValue, 0, 99);
-        valueCh1 = targetCh1;
-        lastChangeTimeCh1 = millis();
-        blinkActiveCh1 = true;
-        Serial.print("Initialized Ch1 target and value to ");
-        Serial.println(targetCh1);
-      } else if (channel == 2 && !lockedCh2) {
-        targetCh2 = constrain(receivedValue, 0, 99);
-        valueCh2 = targetCh2;
-        lastChangeTimeCh2 = millis();
-        blinkActiveCh2 = true;
-        Serial.print("Initialized Ch2 target and value to ");
-        Serial.println(targetCh2);
-      }
-    } else if (type == 1) { // Actual - only update display, preserve target
-      if (channel == 1 && !lockedCh1) {
-        valueCh1 = constrain(receivedValue, 0, 99);
-        lastChangeTimeCh1 = millis();
-        blinkActiveCh1 = true;
-        Serial.print("Updated Ch1 display to ");
-        Serial.print(valueCh1);
-        Serial.print(", target remains ");
-        Serial.println(targetCh1);
-      } else if (channel == 2 && !lockedCh2) {
-        valueCh2 = constrain(receivedValue, 0, 99);
-        lastChangeTimeCh2 = millis();
-        blinkActiveCh2 = true;
-        Serial.print("Updated Ch2 display to ");
-        Serial.print(valueCh2);
-        Serial.print(", target remains ");
-        Serial.println(targetCh2);
-      }
-    }
+    // In NO FEEDBACK MODE, we ignore all incoming values since display is the source of truth
+    Serial.println("NO FEEDBACK MODE: Ignoring incoming value, display controls motors");
   }
   while (Wire.available()) {
     byte discarded = Wire.read();
@@ -353,19 +314,19 @@ void receiveEvent(int howMany) {
   }
 }
 
-// I2C request event
+// I2C request event - NO FEEDBACK MODE
 void requestEvent() {
-  // Respond with both channels' TARGET values (not display values)
+  // Respond with both channels' display values (no separate targets)
   Wire.write((byte)1); // Channel 1 identifier
-  Wire.write((byte)(targetCh1 & 0xFF)); // Channel 1 target
+  Wire.write((byte)(valueCh1 & 0xFF)); // Channel 1 value
   Wire.write((byte)2); // Channel 2 identifier
-  Wire.write((byte)(targetCh2 & 0xFF)); // Channel 2 target
+  Wire.write((byte)(valueCh2 & 0xFF)); // Channel 2 value
   
   // Log request response payload
-  Serial.print("I2C Request Out: Channel=1, Target=");
-  Serial.print(targetCh1);
-  Serial.print("; Channel=2, Target=");
-  Serial.println(targetCh2);
+  Serial.print("I2C Request Out (NO FEEDBACK MODE): Channel=1, Value=");
+  Serial.print(valueCh1);
+  Serial.print("; Channel=2, Value=");
+  Serial.println(valueCh2);
 }
 
 // Update 7-segment display with multiplexing

--- a/src/PlacaDisplay0.1.0.cpp.off
+++ b/src/PlacaDisplay0.1.0.cpp.off
@@ -156,13 +156,11 @@ void handleButtons() {
           valueCh1 = min(99, valueCh1 + 1);
           lastButtonTimeCh1 = currentTime;
           lastChangeTimeCh1 = currentTime;
-          blinkActiveCh1 = true;
           consolidatedCh1 = true;
         } else if (downPressedCh1) {
           valueCh1 = max(0, valueCh1 - 1);
           lastButtonTimeCh1 = currentTime;
           lastChangeTimeCh1 = currentTime;
-          blinkActiveCh1 = true;
           consolidatedCh1 = true;
         }
         if ((upPressedCh1 == false && downPressedCh1 == false) && consolidatedCh1){
@@ -209,13 +207,11 @@ void handleButtons() {
           valueCh2 = min(99, valueCh2 + 1);
           lastButtonTimeCh2 = currentTime;
           lastChangeTimeCh2 = currentTime;
-          blinkActiveCh2 = true;
           sendI2C(2, valueCh2);
         } else if (downPressedCh2) {
           valueCh2 = max(0, valueCh2 - 1);
           lastButtonTimeCh2 = currentTime;
           lastChangeTimeCh2 = currentTime;
-          blinkActiveCh2 = true;
           sendI2C(2, valueCh2);
         }
         if ((upPressedCh2 == false && downPressedCh2 == false) && consolidatedCh2){
@@ -236,36 +232,24 @@ void handleButtons() {
   }
 }
 
-// Update blink states for each channel
+// Update blink states for each channel - NO BLINKING ON VALUE CHANGE
 void updateBlinkState() {
   unsigned long currentTime = millis();
   
-  // Channel 1 blink control
-  if (blinkActiveCh1) {
-    if (currentTime - lastChangeTimeCh1 >= blinkDuration) {
-      blinkActiveCh1 = false;
-      displayOnCh1 = true; // Stay on after blinking
-    } else if (currentTime - lastBlinkTimeCh1 >= blinkInterval) {
-      displayOnCh1 = !displayOnCh1;
-      lastBlinkTimeCh1 = currentTime;
-    }
-  } else if (lockedCh1 && (currentTime - lastBlinkTimeCh1 >= lockBlinkInterval)) {
+  // Channel 1 - only blink when locked, no blink on value change
+  if (lockedCh1 && (currentTime - lastBlinkTimeCh1 >= lockBlinkInterval)) {
     displayOnCh1 = !displayOnCh1;
     lastBlinkTimeCh1 = currentTime;
+  } else if (!lockedCh1) {
+    displayOnCh1 = true; // Always on when not locked
   }
   
-  // Channel 2 blink control
-  if (blinkActiveCh2) {
-    if (currentTime - lastChangeTimeCh2 >= blinkDuration) {
-      blinkActiveCh2 = false;
-      displayOnCh2 = true; // Stay on after blinking
-    } else if (currentTime - lastBlinkTimeCh2 >= blinkInterval) {
-      displayOnCh2 = !displayOnCh2;
-      lastBlinkTimeCh2 = currentTime;
-    }
-  } else if (lockedCh2 && (currentTime - lastBlinkTimeCh2 >= lockBlinkInterval)) {
+  // Channel 2 - only blink when locked, no blink on value change
+  if (lockedCh2 && (currentTime - lastBlinkTimeCh2 >= lockBlinkInterval)) {
     displayOnCh2 = !displayOnCh2;
     lastBlinkTimeCh2 = currentTime;
+  } else if (!lockedCh2) {
+    displayOnCh2 = true; // Always on when not locked
   }
 }
 


### PR DESCRIPTION
# Remove motorboard feedback - display values directly control motors

## Summary
This PR removes the motorboard potentiometer feedback mechanism and display blinking behavior, making the system operate in a unidirectional mode where the display is the sole source of truth.

**Changes:**

**CastleBoard.cpp:**
- Removed all `fetchAllPots()` function calls that read feedback from motorboards via I2C
- CMD1 (get all pots) now returns zeros instead of reading potentiometer values
- Motors still receive set commands but no feedback is read back

**PlacaDisplay0.1.0.cpp.off:**
- Removed separate `targetCh1`/`targetCh2` variables - now using only `valueCh1`/`valueCh2`
- `receiveEvent()` now ignores all incoming I2C messages (logs but doesn't update display)
- `requestEvent()` returns display values directly to control motors
- Removed blinking on button press value changes
- Display stays solid except when locked (locked state still blinks to indicate status)

**Architecture change:** The system now operates display → motors only, with no feedback loop.

## Review & Testing Checklist for Human

⚠️ **Important**: I cannot test this on actual hardware. Please verify:

- [ ] **Motor control works correctly** - Press display buttons and verify motors move to the set positions without feedback
- [ ] **No display blinking on value changes** - Display should stay solid when adjusting values (this was the annoying blink)
- [ ] **Locked state behavior** - Verify locked channels still blink to indicate locked status
- [ ] **No I2C errors** - Check that ignoring motorboard feedback doesn't cause communication issues
- [ ] **End-to-end test** - Test full workflow: adjust multiple channels, lock/unlock, verify motors respond correctly

### Notes
**Risk level**: Medium - Fundamental architecture change without ability to hardware test. The logic appears sound but manual verification is critical.

---
*Requested by: Markus Wirz (markusfwirz@gmail.com, @mde-figu)*  
*Devin session: https://app.devin.ai/sessions/9a2f22fdb32f406d9153bf59e1e0e82b*